### PR TITLE
Fix retrieve original link endpoint. Now method returns JSON with long…

### DIFF
--- a/backend/src/main/java/com/moldavets/url_shortener_api/controller/UrlController.java
+++ b/backend/src/main/java/com/moldavets/url_shortener_api/controller/UrlController.java
@@ -15,7 +15,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -32,11 +31,11 @@ public class UrlController {
 
     private final UrlApplicationService urlApplicationService;
 
-    @Operation(summary = "Redirect to original URL")
+    @Operation(summary = "Retrieve original URL")
     @ApiResponses({
             @ApiResponse(
-                    responseCode = "301",
-                    description = "Successfully redirected to original URL",
+                    responseCode = "200",
+                    description = "Successfully retrieved original URL",
                     content = @Content(schema = @Schema(implementation = UrlResponseLongUrlDto.class), mediaType = "application/json")
             ),
             @ApiResponse(
@@ -51,12 +50,10 @@ public class UrlController {
             )
     })
     @GetMapping("/{shortUrl}")
-    public ResponseEntity<Void> redirectLongUrl(@PathVariable("shortUrl") String shortUrl) {
+    public ResponseEntity<UrlResponseLongUrlDto> redirectLongUrl(@PathVariable("shortUrl") String shortUrl) {
         URI longUrl = urlApplicationService.getLongUrl(shortUrl);
-        HttpHeaders headers = new HttpHeaders();
-        headers.setLocation(longUrl);
-        log.info("Redirecting to - [{}]. Short url is - [{}]", longUrl, shortUrl);
-        return new ResponseEntity<>(headers, HttpStatus.MOVED_PERMANENTLY);
+        log.info("Retrieved original URL - [{}]. Short url is - [{}]", longUrl, shortUrl);
+        return new ResponseEntity<>(new UrlResponseLongUrlDto(longUrl), HttpStatus.OK);
     }
 
     @Operation(summary = "Retrieve info about short URL")

--- a/backend/src/main/java/com/moldavets/url_shortener_api/model/dto/url/UrlResponseLongUrlDto.java
+++ b/backend/src/main/java/com/moldavets/url_shortener_api/model/dto/url/UrlResponseLongUrlDto.java
@@ -2,11 +2,13 @@ package com.moldavets.url_shortener_api.model.dto.url;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.net.URI;
+
 public class UrlResponseLongUrlDto {
     @JsonProperty(value = "long_url")
-    private String longUrl;
+    private URI longUrl;
 
-    public UrlResponseLongUrlDto(String longUrl) {
+    public UrlResponseLongUrlDto(URI longUrl) {
         this.longUrl = longUrl;
     }
 }

--- a/backend/src/test/java/com/moldavets/url_shortener_api/cacheServiceImplTest/CacheServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/moldavets/url_shortener_api/cacheServiceImplTest/CacheServiceImplIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.moldavets.url_shortener_api.CacheServiceImplTest;
+package com.moldavets.url_shortener_api.cacheServiceImplTest;
 
 import com.moldavets.url_shortener_api.service.Impl.CacheServiceImpl;
 import com.redis.testcontainers.RedisContainer;

--- a/backend/src/test/java/com/moldavets/url_shortener_api/cacheServiceImplTest/CacheServiceImplTest.java
+++ b/backend/src/test/java/com/moldavets/url_shortener_api/cacheServiceImplTest/CacheServiceImplTest.java
@@ -1,4 +1,4 @@
-package com.moldavets.url_shortener_api.CacheServiceImplTest;
+package com.moldavets.url_shortener_api.cacheServiceImplTest;
 
 import com.moldavets.url_shortener_api.service.Impl.CacheServiceImpl;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/moldavets/url_shortener_api/controller/UrlControllerIntegrationTest.java
+++ b/backend/src/test/java/com/moldavets/url_shortener_api/controller/UrlControllerIntegrationTest.java
@@ -58,8 +58,8 @@ class UrlControllerIntegrationTest {
     })
     void redirectLongUrl_shouldReturnLongUrl_whenInputContainsStoredShortUrlInDb(String longUrl, String shortUrl) throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get(API_URL + shortUrl))
-                .andExpect(MockMvcResultMatchers.status().isMovedPermanently())
-                .andExpect(MockMvcResultMatchers.header().string("Location", longUrl));
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.long_url").value(longUrl));
     }
 
     @ParameterizedTest

--- a/backend/src/test/java/com/moldavets/url_shortener_api/controller/UrlControllerTest.java
+++ b/backend/src/test/java/com/moldavets/url_shortener_api/controller/UrlControllerTest.java
@@ -50,9 +50,8 @@ class UrlControllerTest {
     void redirectLongUrl_shouldRedirectUserToLongUrl_whenShortUrlStoredInDb () throws Exception {
         when(urlApplicationService.getLongUrl(shortUrl)).thenReturn(URI.create(longUrl));
         mockMvc.perform(MockMvcRequestBuilders.get(API_URL + "/" + shortUrl))
-                .andExpect(MockMvcResultMatchers.status().isMovedPermanently())
-                .andExpect(MockMvcResultMatchers.header().string("Location", longUrl));
-
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.long_url").value(longUrl));
         verify(urlApplicationService, Mockito.times(1)).getLongUrl(anyString());
     }
 

--- a/backend/src/test/java/com/moldavets/url_shortener_api/controller/UrlControllerUnitTest.java
+++ b/backend/src/test/java/com/moldavets/url_shortener_api/controller/UrlControllerUnitTest.java
@@ -2,6 +2,7 @@ package com.moldavets.url_shortener_api.controller;
 
 import com.moldavets.url_shortener_api.model.dto.url.UrlRequestDto;
 import com.moldavets.url_shortener_api.model.dto.url.UrlResponseInfoDto;
+import com.moldavets.url_shortener_api.model.dto.url.UrlResponseLongUrlDto;
 import com.moldavets.url_shortener_api.model.dto.url.UrlResponseShortUrlDto;
 import com.moldavets.url_shortener_api.model.entity.Impl.url.LinkStatus;
 import com.moldavets.url_shortener_api.service.Impl.UrlApplicationService;
@@ -41,12 +42,9 @@ class UrlControllerUnitTest {
         when(urlApplicationService.getLongUrl("test"))
                 .thenReturn(storedLongUrl);
 
-        ResponseEntity<Void> actual = controller.redirectLongUrl("test");
-        URI headerLocation = actual.getHeaders().getLocation();
+        ResponseEntity<UrlResponseLongUrlDto> actual = controller.redirectLongUrl("test");
 
-        assertNotNull(headerLocation);
-        assertEquals(storedLongUrl, headerLocation);
-        assertEquals(HttpStatus.MOVED_PERMANENTLY, actual.getStatusCode());
+        assertEquals(HttpStatus.OK, actual.getStatusCode());
         verify(urlApplicationService, Mockito.times(1)).getLongUrl(anyString());
     }
 


### PR DESCRIPTION
… link instead Location in header, also now method retrun 200 OK instead 301 MOVED PERMANENTLY. Fix tests for UrlController